### PR TITLE
Fix crontab

### DIFF
--- a/crontab
+++ b/crontab
@@ -4,4 +4,4 @@ SHELL=/bin/bash
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 
 0 2 * * * root /usr/local/bin/backup.bash
-0 2 * * * root /usr/local/bin/backup.bash
+0 2 * * * root /usr/local/bin/cleanup.bash


### PR DESCRIPTION
I believe instead of running backup.bash 2 times, intention was running `cleanup.bash` just after `backup.bash`. If so, here is a quick fix 😊